### PR TITLE
Implement -e (errexit) on run steps

### DIFF
--- a/BASH_ENV
+++ b/BASH_ENV
@@ -11,4 +11,4 @@ RUN_SCRIPT="$(ps -p $$ -o args= | xargs -n 1 | tail -n 1)"
 # It's important that this is `exec`uted, because this is what cause this BASH_ENV
 # script to "hijack" the original script's execution. Without the `exec`, $RUN_SCRIPT
 # would also execute in the host.
-exec sudo vagrant ssh -c '$SHELL -se' < "$RUN_SCRIPT"
+exec sudo vagrant ssh -c 'exec $SHELL -se' < "$RUN_SCRIPT"

--- a/BASH_ENV
+++ b/BASH_ENV
@@ -11,4 +11,4 @@ RUN_SCRIPT="$(ps -p $$ -o args= | xargs -n 1 | tail -n 1)"
 # It's important that this is `exec`uted, because this is what cause this BASH_ENV
 # script to "hijack" the original script's execution. Without the `exec`, $RUN_SCRIPT
 # would also execute in the host.
-exec sudo vagrant ssh -c "$(cat "$RUN_SCRIPT")"
+exec sudo vagrant ssh -c '$SHELL -se' < "$RUN_SCRIPT"


### PR DESCRIPTION
errexit causes the script to exit immediately upon error, rather than continue executing the rest of the script. errexit is set by default on the run-step scripts when executing on the GitHub Actions runner, but previously this was not done by default on the guests.