### PR TITLE
Apply resource constraints to Vagrantfile, not Packer HCL file

### DIFF
--- a/freebsd-13.0/.pkr.hcl
+++ b/freebsd-13.0/.pkr.hcl
@@ -6,9 +6,6 @@ locals {
 source "virtualbox-iso" "default" {
   guest_os_type = "FreeBSD_64"
 
-  cpus   = 2
-  memory = 14 * 1024 * 0.75
-
   disk_size            = 14000 # 14 GB
   hard_drive_interface = "scsi"
 

--- a/freebsd-13.0/README.md
+++ b/freebsd-13.0/README.md
@@ -2,7 +2,7 @@
 
 - User: root
 - vCPU: 2
-- RAM: 10.5 GiB
+- RAM: 12 GiB
 - Storage: 10 GiB
 
 ### Included packages

--- a/freebsd-13.0/Vagrantfile
+++ b/freebsd-13.0/Vagrantfile
@@ -14,6 +14,8 @@ Vagrant.configure("2") do |config|
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.provider "virtualbox" do |virtualbox|
+    virtualbox.cpus = 2
+    virtualbox.memory = 12 * 1024
     virtualbox.check_guest_additions = false
   end
 

--- a/netbsd-9.2/.pkr.hcl
+++ b/netbsd-9.2/.pkr.hcl
@@ -6,9 +6,6 @@ locals {
 source "virtualbox-iso" "default" {
   guest_os_type = "NetBSD_64"
 
-  cpus   = 2
-  memory = 14 * 1024 * 0.75
-
   disk_size            = 14000 # 14 GB
   hard_drive_interface = "scsi"
 

--- a/netbsd-9.2/README.md
+++ b/netbsd-9.2/README.md
@@ -2,7 +2,7 @@
 
 - User: root
 - vCPU: 2
-- RAM: 10.5 GiB
+- RAM: 12 GiB
 - Storage: 10 GiB
 
 ### Included packages

--- a/netbsd-9.2/Vagrantfile
+++ b/netbsd-9.2/Vagrantfile
@@ -14,6 +14,8 @@ Vagrant.configure("2") do |config|
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.provider "virtualbox" do |virtualbox|
+    virtualbox.cpus = 2
+    virtualbox.memory = 12 * 1024
     virtualbox.check_guest_additions = false
   end
 

--- a/openbsd-7.0/.pkr.hcl
+++ b/openbsd-7.0/.pkr.hcl
@@ -7,9 +7,6 @@ locals {
 source "virtualbox-iso" "default" {
   guest_os_type = "OpenBSD_64"
 
-  cpus   = 2
-  memory = 14 * 1024 * 0.75
-
   disk_size            = 14000 # 14 GB
   hard_drive_interface = "scsi"
 

--- a/openbsd-7.0/README.md
+++ b/openbsd-7.0/README.md
@@ -2,7 +2,7 @@
 
 - User: root
 - vCPU: 2
-- RAM: 10.5 GiB
+- RAM: 12 GiB
 - Storage: 10 GiB
 
 ### Included file sets

--- a/openbsd-7.0/Vagrantfile
+++ b/openbsd-7.0/Vagrantfile
@@ -14,6 +14,8 @@ Vagrant.configure("2") do |config|
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.provider "virtualbox" do |virtualbox|
+    virtualbox.cpus = 2
+    virtualbox.memory = 12 * 1024
     virtualbox.check_guest_additions = false
   end
 

--- a/openbsd-7.1/.pkr.hcl
+++ b/openbsd-7.1/.pkr.hcl
@@ -6,9 +6,6 @@ locals {
 source "virtualbox-iso" "default" {
   guest_os_type = "OpenBSD_64"
 
-  cpus   = 2
-  memory = 14 * 1024 * 0.75
-
   disk_size            = 14000 # 14 GB
   hard_drive_interface = "scsi"
 

--- a/openbsd-7.1/README.md
+++ b/openbsd-7.1/README.md
@@ -2,7 +2,7 @@
 
 - User: root
 - vCPU: 2
-- RAM: 10.5 GiB
+- RAM: 12 GiB
 - Storage: 10 GiB
 
 ### Included packages

--- a/openbsd-7.1/Vagrantfile
+++ b/openbsd-7.1/Vagrantfile
@@ -14,6 +14,8 @@ Vagrant.configure("2") do |config|
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.provider "virtualbox" do |virtualbox|
+    virtualbox.cpus = 2
+    virtualbox.memory = 12 * 1024
     virtualbox.check_guest_additions = false
   end
 


### PR DESCRIPTION
It turns out I've been doing it all wrong: I should have been defining the CPU and RAM settings in the Vagrantfile, as that is where the VM guest will get its resource definitions from.

The settings that I've been configuring in the Packer file are, confusingly, for _building_ the VM image, not _running_ it.

Also, I'm taking this opportunity to bump up the guest RAM to 12 GiB, because it's just a nice, round, clean number. This does mean a reduction of ~10% RAM for the host (25% -> ~15%), so I'm hopeful that that is enough.